### PR TITLE
add-shell-integation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,16 @@ max_unselected_time = 604800 # 7 days (unit: seconds)
 
 ## Shell Integration
 
+You can set up shell integration to easily navigate to bookmarked paths using the `p` command. The `p` command will change to the selected directory if it's a directory, or output the path if it's a file.
+
 ### Bash and Zsh
 
 Add the following line to your `~/.bashrc` or `~/.zshrc`:
 
 ```bash
-alias cdp='cd "$(pavo)"'
+eval "$(pavo init bash)"
+# or for zsh
+eval "$(pavo init zsh)"
 ```
 
 ### Fish
@@ -78,5 +82,11 @@ alias cdp='cd "$(pavo)"'
 Add the following line to your `~/.config/fish/config.fish`:
 
 ```fish
-alias cdp='cd (pavo)'
+pavo init fish | source
+```
+
+After setting up shell integration, you can use the `p` command to navigate:
+
+```bash
+p  # Opens the TUI to select a bookmarked path and navigates to it
 ```

--- a/README.md
+++ b/README.md
@@ -10,16 +10,14 @@ pavo(from favorite + path) is a tool to bookmark and easily reference files and 
 ### Linux
 
 ```bash
-VERSION='v0.1.1'
-curl -L "https://github.com/taiga533/pavo/releases/download/${VERSION}/pavo-x86_64-unknown-linux-gnu.tar.gz" \
+curl -L "https://github.com/taiga533/pavo/releases/latest/download/pavo-x86_64-unknown-linux-gnu.tar.gz" \
 | tar xz -C /usr/local/bin
 ```
 
 ### MacOS (Apple Silicon only)
 
 ```bash
-VERSION='v0.1.1'
-curl -L "https://github.com/taiga533/pavo/releases/download/${VERSION}/pavo-aarch64-apple-darwin.tar.gz" \
+curl -L "https://github.com/taiga533/pavo/releases/latest/download/pavo-aarch64-apple-darwin.tar.gz" \
 | tar xz -C /usr/local/bin
 ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -10,16 +10,14 @@ pavo（favorite + path）は、編集したいファイルやディレクトリ�
 ### Linux
 
 ```bash
-VERSION='v0.1.1'
-curl -L "https://github.com/taiga533/pavo/releases/download/${VERSION}/pavo-x86_64-unknown-linux-gnu.tar.gz" \
+curl -L "https://github.com/taiga533/pavo/releases/latest/download/pavo-x86_64-unknown-linux-gnu.tar.gz" \
 | tar xz -C /usr/local/bin
 ```
 
 ### MacOS（Apple Silicon のみ）
 
 ```bash
-VERSION='v0.1.1'
-curl -L "https://github.com/taiga533/pavo/releases/download/${VERSION}/pavo-aarch64-apple-darwin.tar.gz" \
+curl -L "https://github.com/taiga533/pavo/releases/latest/download/pavo-aarch64-apple-darwin.tar.gz" \
 | tar xz -C /usr/local/bin
 ```
 
@@ -67,12 +65,16 @@ max_unselected_time = 604800 # 7日 (単位: 秒)
 
 ## シェル統合
 
+`p` コマンドを使用してブックマークしたパスへ簡単に移動できるようにシェル統合を設定できます。`p` コマンドは、選択したパスがディレクトリの場合は移動し、ファイルの場合はパスを出力します。
+
 ### Bash と Zsh
 
 以下の行を `~/.bashrc` または `~/.zshrc` に追加してください：
 
 ```bash
-alias cdp='cd "$(pavo)"'
+eval "$(pavo init bash)"
+# または zsh の場合
+eval "$(pavo init zsh)"
 ```
 
 ### Fish
@@ -80,5 +82,11 @@ alias cdp='cd "$(pavo)"'
 以下の行を `~/.config/fish/config.fish` に追加してください：
 
 ```fish
-alias cdp='cd (pavo)'
+pavo init fish | source
+```
+
+シェル統合を設定した後、`p` コマンドで移動できます：
+
+```bash
+p  # TUI を開いてブックマークしたパスを選択し、移動します
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,12 @@ pub enum Commands {
 
     /// Open the configuration file with the editor specified by the EDITOR environment variable
     Config,
+
+    /// Generate shell integration script
+    Init {
+        /// Shell type to generate script for (bash, zsh, fish)
+        shell: String,
+    },
 }
 
 #[cfg(test)]
@@ -64,6 +70,39 @@ mod tests {
                 assert!(persist);
             }
             _ => panic!("Expected Add command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_init_bash() {
+        let cli = Cli::try_parse_from(&["pavo", "init", "bash"]).unwrap();
+        match cli.command {
+            Some(Commands::Init { shell }) => {
+                assert_eq!(shell, "bash");
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_init_zsh() {
+        let cli = Cli::try_parse_from(&["pavo", "init", "zsh"]).unwrap();
+        match cli.command {
+            Some(Commands::Init { shell }) => {
+                assert_eq!(shell, "zsh");
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_init_fish() {
+        let cli = Cli::try_parse_from(&["pavo", "init", "fish"]).unwrap();
+        match cli.command {
+            Some(Commands::Init { shell }) => {
+                assert_eq!(shell, "fish");
+            }
+            _ => panic!("Expected Init command"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cli;
 pub mod config;
 pub mod entry;
 pub mod pavo;
+pub mod shell;
 #[cfg(test)]
 pub mod test_helper;
 pub mod tui;
@@ -35,6 +36,11 @@ pub fn run() -> anyhow::Result<()> {
         }
         Some(cli::Commands::Clean) => {
             pavo.clean()?;
+            Ok(())
+        }
+        Some(cli::Commands::Init { shell }) => {
+            let script = shell::generate_init_script(&shell)?;
+            println!("{}", script);
             Ok(())
         }
         None => {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,0 +1,106 @@
+/// シェル統合スクリプトを生成する
+///
+/// # Arguments
+/// * `shell` - シェルの種類 ("bash", "zsh", "fish")
+///
+/// # Returns
+/// * `Result<String, anyhow::Error>` - 生成されたスクリプト文字列、または無効なシェルの場合はエラー
+pub fn generate_init_script(shell: &str) -> anyhow::Result<String> {
+    match shell {
+        "bash" | "zsh" => Ok(generate_bash_zsh_script()),
+        "fish" => Ok(generate_fish_script()),
+        _ => Err(anyhow::anyhow!(
+            "Unsupported shell: {}. Supported shells are: bash, zsh, fish",
+            shell
+        )),
+    }
+}
+
+fn generate_bash_zsh_script() -> String {
+    r#"# Pavo shell integration
+# Add this line to your ~/.bashrc or ~/.zshrc:
+# eval "$(pavo init bash)" or eval "$(pavo init zsh)"
+
+p() {
+    local result
+    result=$(pavo)
+    if [ -n "$result" ]; then
+        if [ -d "$result" ]; then
+            cd "$result" || return
+        else
+            echo "$result"
+        fi
+    fi
+}
+"#
+    .to_string()
+}
+
+fn generate_fish_script() -> String {
+    r#"# Pavo shell integration
+# Add this line to your ~/.config/fish/config.fish:
+# pavo init fish | source
+
+function p
+    set -l result (pavo)
+    if test -n "$result"
+        if test -d "$result"
+            cd $result
+        else
+            echo $result
+        end
+    end
+end
+"#
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bashスクリプトが生成できること() {
+        let script = generate_init_script("bash").unwrap();
+        assert!(script.contains("p() {"));
+        assert!(script.contains("cd \"$result\""));
+    }
+
+    #[test]
+    fn test_zshスクリプトが生成できること() {
+        let script = generate_init_script("zsh").unwrap();
+        assert!(script.contains("p() {"));
+        assert!(script.contains("cd \"$result\""));
+    }
+
+    #[test]
+    fn test_fishスクリプトが生成できること() {
+        let script = generate_init_script("fish").unwrap();
+        assert!(script.contains("function p"));
+        assert!(script.contains("cd $result"));
+    }
+
+    #[test]
+    fn test_無効なシェルでエラーが返ること() {
+        let result = generate_init_script("invalid");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unsupported shell"));
+    }
+
+    #[test]
+    fn test_bashスクリプトにインストール手順が含まれること() {
+        let script = generate_init_script("bash").unwrap();
+        assert!(script.contains("eval \"$(pavo init bash)\""));
+        assert!(script.contains("~/.bashrc"));
+    }
+
+    #[test]
+    fn test_fishスクリプトにインストール手順が含まれること() {
+        let script = generate_init_script("fish").unwrap();
+        assert!(script.contains("pavo init fish | source"));
+        assert!(script.contains("~/.config/fish/config.fish"));
+    }
+}


### PR DESCRIPTION
シェル統合を簡単にインストールできるようにしたい。
具体的にはシェルにpを入力することで、pavoを呼び出して出力したパスがディレクトリだったらcdで移動できるようにしたい。