### PR TITLE
feat(shell): auto-register git root directory instead of subdirectories

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -52,7 +52,11 @@ p() {
 # Auto-record git repositories on directory change
 _pavo_record_hook() {
     if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        pavo add 2>/dev/null
+        local git_root
+        git_root=$(git rev-parse --show-toplevel 2>/dev/null)
+        if [ -n "$git_root" ]; then
+            pavo add "$git_root" 2>/dev/null
+        fi
     fi
 }
 
@@ -99,7 +103,10 @@ end
 # Auto-record git repositories on directory change
 function _pavo_record_hook --on-variable PWD
     if git rev-parse --is-inside-work-tree >/dev/null 2>&1
-        pavo add 2>/dev/null
+        set -l git_root (git rev-parse --show-toplevel 2>/dev/null)
+        if test -n "$git_root"
+            pavo add $git_root 2>/dev/null
+        end
     end
 end
 "#

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -52,8 +52,7 @@ p() {
 # Auto-record git repositories on directory change
 _pavo_record_hook() {
     if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        local git_root
-        git_root=$(git rev-parse --show-toplevel 2>/dev/null)
+        local git_root=$(git rev-parse --show-toplevel 2>/dev/null)
         if [ -n "$git_root" ]; then
             pavo add "$git_root" 2>/dev/null
         fi


### PR DESCRIPTION
シェル統合の自動記録機能で、gitリポジトリのサブディレクトリにいる場合でも、
git rev-parse --show-toplevelを使用してリポジトリのルートディレクトリを 検出し、それを登録するように改善しました。

これにより、同じリポジトリ内の異なるサブディレクトリに移動しても、
重複した登録が避けられ、より一貫した挙動になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)